### PR TITLE
Unpinning deps in pyproject toml

### DIFF
--- a/.github/workflows/test_pinned_deps.yml
+++ b/.github/workflows/test_pinned_deps.yml
@@ -34,7 +34,9 @@ jobs:
           environment-file: environment.yml
 
       - name: Install package
-        run: pip install .
+        # Note: editable install for the coverage step to pick up source
+        # correctly. (coverage run --source=src/paste3 -m pytest)
+        run: pip install -e .
 
       - name: Pre-commit checks
         run: pre-commit run --all-files

--- a/.github/workflows/test_unpinned_deps.yml
+++ b/.github/workflows/test_unpinned_deps.yml
@@ -3,10 +3,8 @@ name: Test Unpinned Dependencies
 on:
   push:
     branches: [ main ]
-  pull_request_target:
-    types: [ opened, edited]
+  pull_request:
     branches: [ main ]
-    paths: ['pyproject.toml', 'requirements.txt']
 
 jobs:
   build_wheels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "anndata",
     "scanpy",
     "POT",
-    "numpy",
+    "numpy<2",
     "scipy",
     "scikit-learn",
     "IPython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "anndata==0.10.8",
-    "scanpy==1.10.2",
+    "anndata",
+    "scanpy",
     "POT",
     "numpy",
     "scipy",
-    "scikit-learn==1.5.1",
-    "IPython>=7.18.1",
-    "statsmodels==0.14.2"
+    "scikit-learn",
+    "IPython",
+    "statsmodels"
 ]
 dynamic = ["version"]
 

--- a/tests/test_paste2.py
+++ b/tests/test_paste2.py
@@ -58,7 +58,7 @@ def test_partial_pairwise_align_given_cost_matrix(slices):
         pd.read_csv(output_dir / "align_given_cost_matrix_pairwise_info.csv"),
         rtol=1e-05,
     )
-    assert log == expected_log
+    assert log == pytest.approx(expected_log)
 
 
 @pytest.mark.skip


### PR DESCRIPTION
Unpinned all dependencies in `pyproject.toml` so we're always picking up the latest ones. The package shouldn't place any restrictions on these unless we *know* the code is written for specific versions of the dependencies.

Other minor changes:
 - It makes sense to run unpinned workflow for all PRs towards `main`, not just when the 2 files are modified (if I'm reading this correctly). This is why the unpinned workflow never ran on PR 48.
 - Looks like I misguided you into using `pip install .` for all workflows. For coverage to work correctly in the pinned workflow (the way the rule is written) we do need an editable install.