### PR TITLE
Removed squidpy as docs dependency; using scanpy instead

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,9 @@ jobs:
         run: |
          pip install .[docs]
 
+      - name: List dependencies
+        run: pip freeze
+
       - name: Setup Envvars
         run: |
             if [[ $GITHUB_REF = "refs/tags/"* ]] ; then echo "PASTE3_VERSION=${GITHUB_REF/refs\/tags\//}" ; else echo "PASTE3_VERSION=" ; fi >> $GITHUB_ENV

--- a/docs/source/notebooks/paste2_tutorial.ipynb
+++ b/docs/source/notebooks/paste2_tutorial.ipynb
@@ -122,7 +122,7 @@
    "id": "d1711fae",
    "metadata": {},
    "source": [
-    "We can visualize the slices using [squidpy](https://squidpy.readthedocs.io/en/stable/index.html). In this case, the .obs[\"layer_guess_reordered\"] field stores the layer annotation of each slice, so we use this field to color each spot."
+    "We can visualize the slices using [scanpy](https://scanpy.readthedocs.io/en/stable/). In this case, the .obs[\"layer_guess_reordered\"] field stores the layer annotation of each slice, so we use this field to color each spot."
    ]
   },
   {
@@ -132,10 +132,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pl.spatial(sliceA, color=\"layer_guess_reordered\", spot_size=100, frameon=False)\n",
-    "sc.pl.spatial(sliceB, color=\"layer_guess_reordered\", spot_size=100, frameon=False)\n",
-    "sc.pl.spatial(sliceC, color=\"layer_guess_reordered\", spot_size=100, frameon=False)\n",
-    "sc.pl.spatial(sliceD, color=\"layer_guess_reordered\", spot_size=100, frameon=False)"
+    "sc.pl.spatial(sliceA, color=\"layer_guess_reordered\", spot_size=125, frameon=False)\n",
+    "sc.pl.spatial(sliceB, color=\"layer_guess_reordered\", spot_size=125, frameon=False)\n",
+    "sc.pl.spatial(sliceC, color=\"layer_guess_reordered\", spot_size=125, frameon=False)\n",
+    "sc.pl.spatial(sliceD, color=\"layer_guess_reordered\", spot_size=125, frameon=False)"
    ]
   },
   {

--- a/docs/source/notebooks/paste2_tutorial.ipynb
+++ b/docs/source/notebooks/paste2_tutorial.ipynb
@@ -11,8 +11,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import scanpy as sc\n",
-    "import seaborn as sns\n",
-    "import squidpy as sq"
+    "import seaborn as sns"
    ]
   },
   {
@@ -133,18 +132,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sq.pl.spatial_scatter(\n",
-    "    sliceA, frameon=False, shape=None, color=\"layer_guess_reordered\", figsize=(10, 10)\n",
-    ")\n",
-    "sq.pl.spatial_scatter(\n",
-    "    sliceB, frameon=False, shape=None, color=\"layer_guess_reordered\", figsize=(10, 10)\n",
-    ")\n",
-    "sq.pl.spatial_scatter(\n",
-    "    sliceC, frameon=False, shape=None, color=\"layer_guess_reordered\", figsize=(10, 10)\n",
-    ")\n",
-    "sq.pl.spatial_scatter(\n",
-    "    sliceD, frameon=False, shape=None, color=\"layer_guess_reordered\", figsize=(10, 10)\n",
-    ")"
+    "sc.pl.spatial(sliceA, color=\"layer_guess_reordered\", spot_size=100, frameon=False)\n",
+    "sc.pl.spatial(sliceB, color=\"layer_guess_reordered\", spot_size=100, frameon=False)\n",
+    "sc.pl.spatial(sliceC, color=\"layer_guess_reordered\", spot_size=100, frameon=False)\n",
+    "sc.pl.spatial(sliceD, color=\"layer_guess_reordered\", spot_size=100, frameon=False)"
    ]
   },
   {

--- a/docs/source/notebooks/paste3_dataset.ipynb
+++ b/docs/source/notebooks/paste3_dataset.ipynb
@@ -93,7 +93,7 @@
    "id": "a1cfd794-7890-4f5d-a6dd-bef3b0380980",
    "metadata": {},
    "source": [
-    "Any individual slice can be rendered in a jupyter notebook by simply typing the slice variable name in a cell, which renders the slice using the `squidpy` library. (Note: This is roughly equivalent to doing `squidpy.pl.spatial_scatter(<slice>.adata, ..)`)"
+    "Any individual slice can be rendered in a jupyter notebook by simply typing the slice variable name in a cell, which renders the slice using the `scanpy` library. (Note: This is roughly equivalent to doing `scanpy.pl.spatial(<slice>.adata, ..)`)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ docs = [
     "sphinx-autodoc-annotation",
     "jupyterlab",
     "plotly",
-    "squidpy"
 ]
 
 [project.entry-points."napari.manifest"]

--- a/src/paste3/dataset.py
+++ b/src/paste3/dataset.py
@@ -66,21 +66,16 @@ class Slice:
         return self.name
 
     def _repr_mimebundle_(self, include=None, exclude=None):  # noqa: ARG002
-        try:
-            import squidpy
-        except ImportError:
-            return {}
-        else:
-            squidpy.pl.spatial_scatter(
-                self.adata,
-                frameon=False,
-                shape=None,
-                color="original_clusters",
-                title=str(self),
-            )
+        sc.pl.spatial(
+            self.adata,
+            frameon=False,
+            color="original_clusters",
+            title=str(self),
+            spot_size=1,
+        )
 
-            # squidpy takes care of the rendering so we return an empty dict
-            return {}
+        # scanpy takes care of the rendering so we return an empty dict
+        return {}
 
     @cached_property
     def adata(self):


### PR DESCRIPTION
I realized that `squidpy` is not compatible with `numpy>2.0`, so removed it as a dependency. `Squidpy` was only used to visualize spots, so now I'm using the same functionality provided by `scanpy`. 